### PR TITLE
Add support for opaque types

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,20 @@ defmodule MyStruct do
 end
 ```
 
+You can also generate an opaque type for the struct by specyfing
+`opaque: true`:
+
+```elixir
+defmodule MyOpaqueStruct do
+  use TypedStruct
+
+  # Generate an opaque type for the struct
+  typedstruct opaque: true do
+    field :name, String.t
+  end
+end
+```
+
 ### Documentation
 
 To add a `@typedoc` to the struct type, just add the attribute above the
@@ -280,6 +294,26 @@ case it is enforced. Both options would generate the following type:
         name: String.t() # Not nullable
       }
 ```
+
+Passing `opaque: true` replaces `@type` with `@opaque` in the struct
+type specification:
+
+```elixir
+defmodule Example do
+  use TypedStruct
+
+  typedstruct opaque: true do
+    field :name, String.t()
+  end
+end
+
+# Becomes
+
+@opaque t() :: %__MODULE__{
+          name: String.t()
+        }
+```
+
 
 ## [Contributing](CONTRIBUTING.md)
 


### PR DESCRIPTION
Adds support for generating opaque structure types.
Fixes #10 

```elixir
defmodule Example do
  use TypedStruct

   typedstruct opaque: true do
    field :name, String.t()
  end
end
```

will now become:

```elixir
@opaque t() :: %__MODULE__{
          name: String.t()
        }
```

## Testing
* unit tests pass on both Elixir 1.6.6 and 1.7.4
* created a test project to see if Dialyzer detects the opaque type correctly

Test structs:
```elixir
defmodule MyStruct do
  use TypedStruct

  typedstruct do
    field :name, String.t
  end

  @spec new(String.t) :: t
  def new(name), do: %MyStruct{name: name}
end


defmodule MyOpaqueStruct do
  use TypedStruct

  typedstruct opaque: true do
    field :name, String.t
  end

  @spec new(String.t) :: t
  def new(name), do: %MyOpaqueStruct{name: name}
end
```

This code now correctly generates a dialyzer warning on matching an opaque type:
```elixir
%MyStruct{name: jose} = MyStruct.new("Jose")
%MyOpaqueStruct{name: joe} = MyOpaqueStruct.new("Joe")

"Hello #{jose}, hello #{joe}"
```

```
lib/typed_struct_test.ex:8:opaque_match
Attempted to pattern match against the internal structure of an opaque term.

Type:
MyOpaqueStruct.t()

Pattern:
%MyOpaqueStruct{:name => _joe}

This breaks the opaqueness of the term.
```