### PR TITLE
Add env to field callback

### DIFF
--- a/lib/typed_struct.ex
+++ b/lib/typed_struct.ex
@@ -66,28 +66,21 @@ defmodule TypedStruct do
       end
   """
   defmacro typedstruct(opts \\ [], do: block) do
-    if is_nil(opts[:module]) do
-      quote do
-        Module.eval_quoted(
-          __ENV__,
-          TypedStruct.__typedstruct__(
-            unquote(Macro.escape(block)),
-            unquote(opts)
-          )
-        )
-      end
-    else
-      quote do
-        defmodule unquote(opts[:module]) do
-          Module.eval_quoted(
-            __ENV__,
-            TypedStruct.__typedstruct__(
-              unquote(Macro.escape(block)),
-              unquote(opts)
-            )
-          )
+    ast = TypedStruct.__typedstruct__(block, opts)
+
+    case opts[:module] do
+      nil ->
+        quote do
+          # create a lexical scope
+          (fn -> unquote(ast) end).()
         end
-      end
+
+      module ->
+        quote do
+          defmodule unquote(module) do
+            unquote(ast)
+          end
+        end
     end
   end
 

--- a/lib/typed_struct/plugin.ex
+++ b/lib/typed_struct/plugin.ex
@@ -11,17 +11,16 @@ defmodule TypedStruct.Plugin do
   ## Plugin definition
 
   A TypedStruct plugin is a module that implements `TypedStruct.Plugin`. Three
-  callbacks can be used to inject code at different steps:
+  callbacks are available to you for injecting code at different steps:
 
     * `c:init/1` lets you inject code where the `TypedStruct.plugin/2` macro is
       called,
-    * `c:field/3` lets you inject code on each field definition,
+    * `c:field/4` lets you inject code on each field definition,
     * `c:after_definition/1` lets you insert code after the struct and its type
       have been defined.
 
-  To provide the maximum flexibility, the last two callbacks are optional and a
-  default implementation of `c:init/1` is defined when `use`-ing the module, so
-  that you do not have to write it yourself if you do not need it.
+  `use`-ing this module will inject default, overrideable implementations of all
+  three, so you only have to implement those you care about.
 
   ### Example
 
@@ -108,10 +107,12 @@ defmodule TypedStruct.Plugin do
 
         # The field callback is called for each field defined in the typedstruct
         # block. You get exactly what the user has passed to the field macro,
-        # plus options from every plugin init.
+        # plus options from every plugin init. The `env` variable contains the
+        # environment as it stood at the moment of the corresponding
+        # `TypedStruct.field/3` call.
         @impl true
-        @spec field(atom(), any(), keyword()) :: Macro.t()
-        def field(name, _type, opts) do
+        @spec field(atom(), any(), keyword(), Macro.Env.t()) :: Macro.t()
+        def field(name, _type, opts, _env) do
           # Same as for the struct description, we want to upcase at build time
           # if necessary. As we do not have access to the module here, we cannot
           # access @upcase. This is not an issue since the option is
@@ -148,14 +149,24 @@ defmodule TypedStruct.Plugin do
   """
   @macrocallback init(opts :: keyword()) :: Macro.t()
 
+  @doc deprecated: "Use TypedStruct.Plugin.field/4 instead"
+  @callback field(name :: atom(), type :: any(), opts :: keyword()) ::
+              Macro.t()
+
   @doc """
   Injects code after each field definition.
 
-  `name` and `type` are the exact values passed to the `TypedStruct.field/3`
+  `name` and `type` are the exact values passed to the `TypedStruct.field/4`
   macro in the `typedstruct` block. `opts` is the concatenation of the options
-  passed to the `field` macro and those from the plugin init.
+  passed to the `field` macro and those from the plugin init. `env` is the
+  environment at the time of each field definition.
   """
-  @callback field(name :: atom(), type :: any(), opts :: keyword()) ::
+  @callback field(
+              name :: atom(),
+              type :: any(),
+              opts :: keyword(),
+              env :: Macro.Env.t()
+            ) ::
               Macro.t()
 
   @doc """
@@ -163,9 +174,7 @@ defmodule TypedStruct.Plugin do
   """
   @callback after_definition(opts :: keyword()) :: Macro.t()
 
-  # All the callbacks are optional so the user has more flexibility. Only init/1
-  # is mandatory but an overrideable default is defined when use-ing the module.
-  @optional_callbacks [field: 3, after_definition: 1]
+  @optional_callbacks [field: 3]
 
   @doc false
   defmacro __using__(_opts) do
@@ -174,7 +183,18 @@ defmodule TypedStruct.Plugin do
 
       @doc false
       defmacro init(_opts), do: nil
-      defoverridable init: 1
+
+      @doc false
+      def field(name, type, opts, _env) do
+        if {:field, 3} in __MODULE__.__info__(:functions) do
+          field(name, type, opts)
+        end
+      end
+
+      @doc false
+      def after_definition(_opts), do: nil
+
+      defoverridable init: 1, field: 4, after_definition: 1
     end
   end
 end

--- a/test/typed_struct/plugin_test.exs
+++ b/test/typed_struct/plugin_test.exs
@@ -137,6 +137,12 @@ defmodule TypedStruct.PluginTest do
     assert TestStruct.function_defined_by_the_plugin_after_definition()
   end
 
+  test "empty plugin compiled without error" do
+    defmodule EmptyPlugin do
+      use TypedStruct.Plugin
+    end
+  end
+
   ############################################################################
   ##                                Problems                                ##
   ############################################################################

--- a/test/typed_struct/plugin_type_test.exs
+++ b/test/typed_struct/plugin_type_test.exs
@@ -1,0 +1,68 @@
+defmodule TypedStruct.PluginEnvTest do
+  @moduledoc """
+  Test the the env argument in the field/4 plugin callback.
+  """
+
+  use ExUnit.Case
+
+  ############################################################################
+  ##                               Test data                                ##
+  ############################################################################
+
+  defmodule TestPlugin do
+    use TypedStruct.Plugin
+
+    @impl true
+    def field(name, type, _opts, env) do
+      module = module_from_type(type, env)
+
+      quote do
+        def get_meaning_of_life(unquote(name)) do
+          unquote(module).meaning_of_life()
+        end
+      end
+    end
+
+    defp module_from_type(type_ast, env) do
+      {_ast, module} =
+        Macro.prewalk(type_ast, nil, fn
+          {:__aliases__, _meta, _list} = ast, nil ->
+            mod = Macro.expand(ast, env)
+            {ast, mod}
+
+          ast, acc ->
+            {ast, acc}
+        end)
+
+      module
+    end
+  end
+
+  defmodule TestDependency do
+    def meaning_of_life, do: 42
+  end
+
+  defmodule TestModule do
+    alias TestDependency, as: FirstDependency
+    use TypedStruct
+
+    typedstruct do
+      plugin TestPlugin
+      alias TestDependency, as: SecondDependency
+      field :first, FirstDependency.t()
+      field :second, SecondDependency.t()
+    end
+  end
+
+  ############################################################################
+  ##                                 Tests                                  ##
+  ############################################################################
+
+  test "The field/4 env includes aliases made prior to typedstruct call" do
+    assert TestModule.get_meaning_of_life(:first) == 42
+  end
+
+  test "The field/4 env includes aliases made within typedstruct call" do
+    assert TestModule.get_meaning_of_life(:second) == 42
+  end
+end


### PR DESCRIPTION
This PR does two different things:
1. (refactor) Replace `Module.eval_quoted` calls by using a `@before_compile` callback. You'd mentioned you were open to strategies for doing that [here](https://github.com/ejpcmac/typed_struct/issues/21#issuecomment-1003442610).
2. (feature) Add the current Macro.Env as a fourth param to the field callback. The addition of `field/4` is fully backwards-compatible with `field/3`.

What do you think?
