### PR TITLE
Fix typo in docs

### DIFF
--- a/lib/typed_struct.ex
+++ b/lib/typed_struct.ex
@@ -57,7 +57,7 @@ defmodule TypedStruct do
       defmodule MyModule do
         use TypedStruct
 
-        typedstruct, module: Struct do
+        typedstruct module: Struct do
           field :field_one, String.t()
           field :field_two, integer(), enforce: true
           field :field_three, boolean(), enforce: true


### PR DESCRIPTION
| Before | After |
|-----|-----|
| typedstruct, module: Struct do | typedstruct module: Struct do |

Copying and pasting from the existing doc fails to compile with the error:

```$ mix compile
Compiling 2 files (.ex)
== Compilation error in file lib/my_app/my_module.ex ==
** (SyntaxError) lib/my_app/my_module.ex:21:31: syntax error before: do
    |
 21 |   typedstruct, module: Struct do
    |                               ^
    (elixir 1.13.1) lib/kernel/parallel_compiler.ex:346: anonymous fn/5 in Kernel.ParallelCompiler.spawn_workers/7
```