### PR TITLE
Add parameters option

### DIFF
--- a/lib/typed_struct.ex
+++ b/lib/typed_struct.ex
@@ -97,7 +97,7 @@ defmodule TypedStruct do
 
         @spec start_repair(t(new())) :: t(in_progress())
         def start_repair(order) do
-          put_in(order.state, %{status: :in_progress, progress: 0})
+          %{order | state: %{status: :in_progress, progress: 0}}
         end
 
         @spec advance_repair(t(in_progress()), integer()) :: t(in_progress())
@@ -107,7 +107,7 @@ defmodule TypedStruct do
 
         @spec finish_repair(t(in_progress())) :: t(completed())
         def finish_repair(order) do
-          put_in(order.state, %{status: :completed})
+          %{order | state: %{status: :completed}}
         end
       end
 


### PR DESCRIPTION
Hello,

First of all thank you very much for your library, it's great!

I stumbled upon this [blog post explaining the Typestate pattern](https://erszcz.medium.com/make-illegal-states-unrepresentable-but-how-the-typestate-pattern-in-erlang-16b37b090d9d), and thought it was great too. Unfortunately I don't think it's possible to implement this with `typed_struct` because the generated `t()` can't have parameters.

So I tried to add a `parameters` option to `typedstruct`, but couldn't get it to work:
```
warning: variable "a" does not exist and is being expanded to "a()", please use parentheses to remove the ambiguity or change the variable name
  test/typed_struct_test.exs:67: TypedStructTest.ParameterizedTestStruct


== Compilation error in file test/typed_struct_test.exs ==
** (CompileError) test/typed_struct_test.exs:67: undefined function a/0 (there is no such import)
    (typed_struct 0.3.0) expanding macro: TypedStruct.__type__/2
    test/typed_struct_test.exs:67: TypedStructTest.ParameterizedTestStruct (module)
    (typed_struct 0.3.0) expanding macro: TypedStruct.typedstruct/2
    test/typed_struct_test.exs:67: TypedStructTest.ParameterizedTestStruct (module)
```

If you think this would be a good addition to your library, could you please have a look and nudge me in the good direction?

I feel I'm close to success but it's my first time fiddling with Elixir macros and honestly I'm lost. It looks like the problem comes from the `bind_quoted: ` stuff in `__type__()` but I don't really understand what it does and couldn't find information about it, nor understand why you're using it.

Thanks,
Luper