### PR TITLE
feat: add support for visibility option and typedrecord

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,0 +1,2 @@
+* Jean-Philippe Cugnet (author)
+* Serge Aleynikov (implemented visibility and defrecord)

--- a/README.md
+++ b/README.md
@@ -81,6 +81,30 @@ end
 
 Thanks to TypedStruct, this is now possible :)
 
+This library can also be used for defining typed records:
+
+```elixir
+defmodule Person do
+  use TypedStruct
+
+  typedrecord :person do
+    @typedoc "A person"
+
+    field :name, String.t(),
+    field :age,  non_neg_integer(), default: 0
+  end
+end
+```
+
+The code above will be expanded to:
+
+```elixir
+defmodule Person do
+  Record.defrecord(:person, name: nil, age: 0)
+  @type person :: {:person, String.t, non_neg_integer}
+end
+```
+
 ## Usage
 
 ### Setup
@@ -154,8 +178,31 @@ defmodule MyStruct do
   end
 end
 ```
+You can also generate an opaque or private type for the struct:
 
-You can also generate an opaque type for the struct:
+```elixir
+defmodule MyOpaqueStruct do
+  use TypedStruct
+
+  # Generate an opaque type for the struct.
+  typedstruct visibility: :opaque do
+    field :name, String.t()
+  end
+end
+```
+
+```elixir
+defmodule MyPrivateStruct do
+  use TypedStruct
+
+  # Generate a private type for the struct.
+  typedstruct visibility: :private do
+    field :name, String.t()
+  end
+end
+```
+
+The opaque and private types can also be defined using `opaque` or `private` property:
 
 ```elixir
 defmodule MyOpaqueStruct do

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ The code above will be expanded to:
 
 ```elixir
 defmodule Person do
+  use Record
   Record.defrecord(:person, name: nil, age: 0)
   @type person :: {:person, String.t, non_neg_integer}
 end
@@ -178,7 +179,8 @@ defmodule MyStruct do
   end
 end
 ```
-You can also generate an opaque or private type for the struct:
+You can also generate an opaque or private type for the struct by using
+the `visibility: :opaque | :private | :public` option:
 
 ```elixir
 defmodule MyOpaqueStruct do
@@ -202,7 +204,8 @@ defmodule MyPrivateStruct do
 end
 ```
 
-The opaque and private types can also be defined using `opaque` or `private` property:
+The opaque and private types can also be defined using `opaque` or `private`
+boolean option:
 
 ```elixir
 defmodule MyOpaqueStruct do

--- a/README.md
+++ b/README.md
@@ -81,31 +81,6 @@ end
 
 Thanks to TypedStruct, this is now possible :)
 
-This library can also be used for defining typed records:
-
-```elixir
-defmodule Person do
-  use TypedStruct
-
-  typedrecord :person do
-    @typedoc "A person"
-
-    field :name, String.t(),
-    field :age,  non_neg_integer(), default: 0
-  end
-end
-```
-
-The code above will be expanded to:
-
-```elixir
-defmodule Person do
-  use Record
-  Record.defrecord(:person, name: nil, age: 0)
-  @type person :: {:person, String.t, non_neg_integer}
-end
-```
-
 ## Usage
 
 ### Setup
@@ -158,6 +133,21 @@ end
 Each field is defined through the
 [`field/2`](https://hexdocs.pm/typed_struct/TypedStruct.html#field/2) macro.
 
+To define a record use the `typedrecord` block:
+
+```elixir
+defmodule Person do
+  use TypedStruct
+
+  typedrecord :person do
+    @typedoc "A person"
+
+    field :name, String.t(),
+    field :age,  non_neg_integer(), default: 0
+  end
+end
+```
+
 ### Options
 
 If you want to enforce all the keys by default, you can do:
@@ -199,20 +189,6 @@ defmodule MyPrivateStruct do
 
   # Generate a private type for the struct.
   typedstruct visibility: :private do
-    field :name, String.t()
-  end
-end
-```
-
-The opaque and private types can also be defined using `opaque` or `private`
-boolean option:
-
-```elixir
-defmodule MyOpaqueStruct do
-  use TypedStruct
-
-  # Generate an opaque type for the struct.
-  typedstruct opaque: true do
     field :name, String.t()
   end
 end
@@ -286,6 +262,8 @@ defmodule MyStruct do
   end
 end
 ```
+
+Presently plugins are not supported by the `typedrecord` block.
 
 ### Some available plugins
 
@@ -423,6 +401,29 @@ defmodule MyModule do
             field: term() | nil
           }
   end
+end
+```
+
+To define a typed record, the following definition of the `typedrecord`:
+
+```elixir
+defmodule Person do
+  use TypedStruct
+  typedrecord :person do
+    @typedoc "A person"
+    field :name, String.t(),
+    field :age,  non_neg_integer(), default: 0
+  end
+end
+```
+
+becomes:
+
+```elixir
+defmodule Person do
+  use Record
+  Record.defrecord(:person, name: nil, age: 0)
+  @type person :: {:person, String.t()|nil, non_neg_integer()}
 end
 ```
 

--- a/lib/typed_struct.ex
+++ b/lib/typed_struct.ex
@@ -32,12 +32,11 @@ defmodule TypedStruct do
   ## Options
 
     * `enforce`    - if set to true, sets `enforce: true` to all fields by default.
-                     This can be overridden by setting `enforce: false` or a default value on
-                     individual fields.
+      This can be overridden by setting `enforce: false` or a default value on
+      individual fields.
     * `visibility` - one of the values: `:public` (default), `:private`, `:opaque`.
-    * `opaque`     - if set to true, creates an opaque  type for the struct.
-    * `private`    - if set to true, creates an private type for the struct.
     * `module`     - if set, creates the struct in a submodule named `module`.
+    * `opaque`     - (deprecated) if set to true, creates an opaque type for the struct.
 
   ## Examples
 
@@ -200,13 +199,9 @@ defmodule TypedStruct do
 
   @doc false
   def __visibility__(opts) do
+    # For backward compatibility support `opaque: true` or else default to public
     Keyword.get(opts, :visibility) ||
-      Enum.reduce_while([:opaque, :private, :public], :public, fn x, a ->
-        case Keyword.get(opts, x) do
-          true -> {:halt, x}
-          nil -> {:cont, a}
-        end
-      end)
+      ((Keyword.get(opts, :opaque) == true && :opaque) || :public)
   end
 
   @doc false

--- a/lib/typed_struct.ex
+++ b/lib/typed_struct.ex
@@ -49,7 +49,6 @@ defmodule TypedStruct do
           field :field_two, integer(), enforce: true
           field :field_three, boolean(), enforce: true
           field :field_four, atom(), default: :hey
-          field :field_four, atom(), default: :hey
         end
       end
 
@@ -58,7 +57,7 @@ defmodule TypedStruct do
       defmodule MyStruct do
         use TypedStruct
 
-        typedstruct enforce: true, visibility: :private do
+        typedstruct enforce: true do
           field :field_one, String.t(), enforce: false
           field :field_two, integer()
           field :field_three, boolean()

--- a/test/typed_record_test.exs
+++ b/test/typed_record_test.exs
@@ -1,0 +1,252 @@
+defmodule TypedRecordTest do
+  use ExUnit.Case
+
+  ############################################################################
+  ##                               Test data                                ##
+  ############################################################################
+
+  # Store the bytecode so we can get information from it.
+  {:module, _name, bytecodepublic1, _exports} =
+    defmodule TestStructPublic1 do
+      use TypedStruct
+
+      typedrecord :user do
+        field :one, integer(), default: 1
+        field :two, String.t()
+        field :three, String.t(), default: "def"
+        field :four, atom(), default: :hi
+      end
+    end
+
+  {:module, _name, bytecodepublic2, _exports} =
+    defmodule TestStructPublic2 do
+      use TypedStruct
+
+      typedrecord :user, tag: User do
+        field :one, integer(), default: 1
+        field :two, String.t()
+        field :three, String.t(), default: "def"
+        field :four, atom(), default: :hi
+      end
+    end
+
+  {:module, _name, bytecodepublic3, _exports} =
+    defmodule TestStructPublic3 do
+      use TypedStruct
+
+      typedrecord :user, visibility: :public do
+        field :one, integer(), default: 1
+        field :two, String.t()
+        field :three, String.t(), default: "def"
+        field :four, atom(), default: :hi
+      end
+    end
+
+  {:module, _name, bytecode_opaque1, _exports} =
+    defmodule OpaqueTestStruct1 do
+      use TypedStruct
+
+      typedrecord :user, opaque: true do
+        field :int, integer()
+      end
+    end
+
+  {:module, _name, bytecode_opaque2, _exports} =
+    defmodule OpaqueTestStruct2 do
+      use TypedStruct
+
+      typedrecord :user, visibility: :opaque do
+        field :int, integer()
+      end
+    end
+
+  {:module, _name, bytecode_private, _exports} =
+    defmodule PrivateTestStruct do
+      use TypedStruct
+
+      typedrecord :user, visibility: :private do
+        field :int, integer()
+      end
+
+      # Needed so that the compiler doesn't remove unused private type t()
+      @opaque tt :: user
+    end
+
+  defmodule TestRecModule do
+    use TypedStruct
+
+    typedrecord :user, module: Rec do
+      field :field, integer(), default: 1
+    end
+  end
+
+  @bytecode1 bytecodepublic1
+  @bytecode2 bytecodepublic2
+  @bytecode3 bytecodepublic3
+  @bytecode_opaque1 bytecode_opaque1
+  @bytecode_opaque2 bytecode_opaque2
+  @bytecode_private bytecode_private
+
+  ############################################################################
+  ##                             Standard cases                             ##
+  ############################################################################
+
+  test "generates the record with its defaults" do
+    require TypedRecordTest.TestStructPublic1
+    assert TestStructPublic1.user() == {:user, 1, nil, "def", :hi}
+  end
+
+  test "generates a type for the record in default case or if `visibility: :public` is set" do
+    # Define a second struct with the type expected for TestStruct.
+    {:module, _name, bytecode1, _exports} =
+      defmodule TestRecord1 do
+        require Record
+        Record.defrecord(:user, one: 1, two: nil, three: "def", four: :hi)
+
+        @type user() :: {:user, integer, String.t(), String.t(), atom}
+      end
+
+    type0 = extract_first_type(bytecode1)
+    type1 = extract_first_type(@bytecode1)
+
+    assert type0 == type1
+
+    # Define a second struct with the type expected for TestStruct.
+    {:module, _name, bytecode2, _exports} =
+      defmodule TestRecordTag do
+        require Record
+        Record.defrecord(:user, User, one: 1, two: nil, three: "def", four: :hi)
+
+        @type user() :: {User, integer, String.t(), String.t(), atom}
+      end
+
+    type1 = extract_first_type(bytecode2)
+    type2 = extract_first_type(@bytecode2)
+
+    assert type1 == type2
+
+    type3 = extract_first_type(@bytecode3)
+
+    assert type0 == type3
+  end
+
+  test "generates an opaque type if `opaque: true` or `visibility: :opaque` is set" do
+    # Define a second struct with the type expected for TestStruct.
+    {:module, _name, bytecode_expected, _exports} =
+      defmodule TestRecord2 do
+        require Record
+        Record.defrecord(:user, int: 1)
+
+        @opaque user() :: {:user, integer}
+      end
+
+    type1 = extract_first_type(@bytecode_opaque1, :opaque)
+    type2 = extract_first_type(bytecode_expected, :opaque)
+
+    assert type1 == type2
+
+    type3 = extract_first_type(@bytecode_opaque2, :opaque)
+
+    assert type3 == type2
+  end
+
+  test "generates a private type if `visibility: private` is set" do
+    # Define a second struct with the type expected for TestStruct.
+    {:module, _name, bytecode_private_expected, _exports} =
+      defmodule TestRecord3 do
+        require Record
+        Record.defrecord(:user, int: 1)
+
+        @typep user() :: {:user, integer}
+        @opaque t2 :: user
+      end
+
+    type1 = extract_first_type(@bytecode_private, :typep)
+    type2 = extract_first_type(bytecode_private_expected, :typep)
+
+    assert type1 == type2
+  end
+
+  test "generates the struct in a submodule if `module: ModuleName` is set" do
+    require TestRecModule.Rec
+    assert TestRecModule.Rec.user() == {:user, 1}
+  end
+
+  ############################################################################
+  ##                                Problems                                ##
+  ############################################################################
+
+  test "Typedrecord missing record name" do
+    assert_raise CompileError, ~r"undefined function typedrecord/1", fn ->
+      defmodule ScopeTest do
+        use TypedStruct
+
+        typedrecord do
+          field :in_scope, term()
+        end
+      end
+    end
+  end
+
+  test "it is not possible to add twice a field with the same name" do
+    assert_raise ArgumentError, "the field :name is already set", fn ->
+      defmodule InvalidStruct do
+        use TypedStruct
+
+        typedrecord :user do
+          field :name, String.t()
+          field :name, integer()
+        end
+      end
+    end
+  end
+
+  ############################################################################
+  ##                                Helpers                                 ##
+  ############################################################################
+
+  # Extracts the first type from a module.
+  defp extract_first_type(bytecode, type_keyword \\ :type) do
+    case Code.Typespec.fetch_types(bytecode) do
+      {:ok, types} -> Keyword.get(types, type_keyword) |> standardise
+      _ -> nil
+    end
+  end
+
+  # Standardises a type (removes line numbers and renames the struct to the
+  # standard struct name).
+  defp standardise(type_info)
+
+  defp standardise({name, tp, params}) when is_tuple(tp),
+    do: {name, standardise(tp), params}
+
+  defp standardise({:type, _, :union, list}) when is_list(list) do
+    list =
+      Enum.map(list, &standardise(&1))
+      |> Enum.filter(&(&1 != nil and &1 != []))
+
+    case list do
+      [one] -> standardise(one)
+      _ -> {:type, :line, list}
+    end
+  end
+
+  defp standardise({:type, _, :union, [value, nil]}),
+    do: {:type, :line, standardise(value)}
+
+  defp standardise({:type, _, type, params}),
+    do: {:type, :line, type, standardise(params)}
+
+  defp standardise({:remote_type, _, params}),
+    do: {:remote_type, :line, standardise(params)}
+
+  defp standardise({:atom, _, value}), do: value
+
+  defp standardise({type, _, litteral}),
+    do: {type, :line, standardise(litteral)}
+
+  defp standardise(type) when is_atom(type), do: type
+
+  defp standardise(list) when is_list(list),
+    do: for(i <- list, i != [], do: standardise(i))
+end

--- a/test/typed_struct_test.exs
+++ b/test/typed_struct_test.exs
@@ -97,7 +97,6 @@ defmodule TypedStructTest do
 
   @bytecode bytecode
   @bytecode_public bytecode_public
-  @bytecode_opaque_legacy bytecode_opaque_legacy
   @bytecode_opaque bytecode_opaque
   @bytecode_private bytecode_private
   @bytecode_noalias bytecode_noalias
@@ -145,7 +144,7 @@ defmodule TypedStructTest do
   test "generates a type for the struct in default case" do
     # Define a second struct with the type expected for TestStruct.
     {:module, _name, bytecode2, _exports} =
-      defmodule TestStruct1 do
+      defmodule TestStruct0 do
         defstruct [:int, :string, :string_with_default, :mandatory_int]
 
         @type t() :: %__MODULE__{
@@ -166,7 +165,7 @@ defmodule TypedStructTest do
     type2 =
       bytecode2
       |> extract_first_type()
-      |> standardise(TypedStructTest.TestStruct1)
+      |> standardise(TypedStructTest.TestStruct0)
 
     assert type1 == type2
   end
@@ -225,7 +224,7 @@ defmodule TypedStructTest do
   test "generates an opaque type if `visibility: :opaque` is set" do
     # Define a second struct with the type expected for TestStruct.
     {:module, _name, bytecode_expected, _exports} =
-      defmodule TestStruct2 do
+      defmodule TestStruct3 do
         defstruct [:int]
 
         @opaque t() :: %__MODULE__{
@@ -241,7 +240,7 @@ defmodule TypedStructTest do
     type2 =
       bytecode_expected
       |> extract_first_type(:opaque)
-      |> standardise(TypedStructTest.TestStruct2)
+      |> standardise(TypedStructTest.TestStruct3)
 
     assert type1 == type2
   end
@@ -249,7 +248,7 @@ defmodule TypedStructTest do
   test "generates a private type if `visibility: private` is set" do
     # Define a second struct with the type expected for TestStruct.
     {:module, _name, bytecode_private_expected, _exports} =
-      defmodule TestStruct3 do
+      defmodule TestStruct4 do
         defstruct [:int]
 
         @typep t :: %__MODULE__{int: integer() | nil}
@@ -266,7 +265,7 @@ defmodule TypedStructTest do
     type2 =
       bytecode_private_expected
       |> extract_first_type(:typep)
-      |> standardise(TypedStructTest.TestStruct3)
+      |> standardise(TypedStructTest.TestStruct4)
 
     assert type1 == type2
   end

--- a/test/typed_struct_test.exs
+++ b/test/typed_struct_test.exs
@@ -60,7 +60,8 @@ defmodule TypedStructTest do
         field :int, integer()
       end
 
-      @opaque tt :: t  # Needed so that the compiler doesn't remove unused private type t()
+      # Needed so that the compiler doesn't remove unused private type t()
+      @opaque tt :: t
     end
 
   defmodule EnforcedTypedStruct do
@@ -157,7 +158,10 @@ defmodule TypedStructTest do
 
     # Get both types and standardise them (remove line numbers and rename
     # the second struct with the name of the first one).
-    type1 = @bytecode1 |> extract_first_type() |> standardise(TypedStructTest.TestStructPublic1)
+    type1 =
+      @bytecode1
+      |> extract_first_type()
+      |> standardise(TypedStructTest.TestStructPublic1)
 
     type2 =
       bytecode2
@@ -166,7 +170,10 @@ defmodule TypedStructTest do
 
     assert type1 == type2
 
-    type3 = @bytecode2 |> extract_first_type() |> standardise(TypedStructTest.TestStructPublic2)
+    type3 =
+      @bytecode2
+      |> extract_first_type()
+      |> standardise(TypedStructTest.TestStructPublic2)
 
     assert type3 == type2
   end
@@ -210,7 +217,7 @@ defmodule TypedStructTest do
       defmodule TestStruct3 do
         defstruct [:int]
 
-        @typep  t  :: %__MODULE__{int: integer() | nil}
+        @typep t :: %__MODULE__{int: integer() | nil}
         @opaque t2 :: t
       end
 
@@ -318,7 +325,7 @@ defmodule TypedStructTest do
 
   # Standardises a type (removes line numbers and renames the struct to the
   # standard struct name).
-  defp standardise(type_info, struct \\ @standard_struct_name)
+  defp standardise(type_info, struct)
 
   defp standardise({name, type, params}, struct) when is_tuple(type),
     do: {name, standardise(type, struct), params}


### PR DESCRIPTION
This is a backward-compatible change that adds two new features:
- A `visibility` attribute (`:public`, `:private`, `:opaque`)
- A `typedrecord` macro for defining a custom Record with a type