### PR TITLE
feat: add support for a visibility feature (part1 of PR#33)

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,0 +1,2 @@
+* Jean-Philippe Cugnet (author)
+* Serge Aleynikov (implemented visibility and defrecord)

--- a/README.md
+++ b/README.md
@@ -154,15 +154,26 @@ defmodule MyStruct do
   end
 end
 ```
-
-You can also generate an opaque type for the struct:
+You can also generate an opaque or private type for the struct by using
+the `visibility: :opaque | :private | :public` option:
 
 ```elixir
 defmodule MyOpaqueStruct do
   use TypedStruct
 
   # Generate an opaque type for the struct.
-  typedstruct opaque: true do
+  typedstruct visibility: :opaque do
+    field :name, String.t()
+  end
+end
+```
+
+```elixir
+defmodule MyPrivateStruct do
+  use TypedStruct
+
+  # Generate a private type for the struct.
+  typedstruct visibility: :private do
     field :name, String.t()
   end
 end

--- a/lib/typed_struct.ex
+++ b/lib/typed_struct.ex
@@ -127,17 +127,17 @@ defmodule TypedStruct do
     case TypedStruct.__visibility__(opts) do
       :public ->
         quote bind_quoted: [types: types] do
-          @type t() :: %__MODULE__{unquote_splicing(types)}
+          @type(t() :: %__MODULE__{unquote_splicing(types)})
         end
 
       :opaque ->
         quote bind_quoted: [types: types] do
-          @opaque t() :: %__MODULE__{unquote_splicing(types)}
+          @opaque(t() :: %__MODULE__{unquote_splicing(types)})
         end
 
       :private ->
         quote bind_quoted: [types: types] do
-          @typep t() :: %__MODULE__{unquote_splicing(types)}
+          @typep(t() :: %__MODULE__{unquote_splicing(types)})
         end
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -11,6 +11,7 @@ defmodule TypedStruct.MixProject do
       elixir: "~> 1.6",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
+      elixirc_paths: elixirc_paths(),
 
       # Tools
       dialyzer: dialyzer(),
@@ -55,6 +56,10 @@ defmodule TypedStruct.MixProject do
       # Documentation dependencies
       {:ex_doc, ">= 0.0.0", only: :docs, runtime: false}
     ]
+  end
+
+  defp elixirc_paths() do
+    if Mix.env() == :test, do: ["lib", "test"], else: ["lib"]
   end
 
   # Dialyzer configuration

--- a/test/test_structs.ex
+++ b/test/test_structs.ex
@@ -1,0 +1,111 @@
+defmodule TypedStructs.TestStruct do
+  # Store the bytecode so we can get information from it.
+  defmodule Actual do
+    use TypedStruct
+
+    typedstruct do
+      field :int, integer()
+      field :string, String.t()
+      field :string_with_default, String.t(), default: "default"
+      field :mandatory_int, integer(), enforce: true
+    end
+
+    def enforce_keys, do: @enforce_keys
+  end
+
+  defmodule Expected do
+    defstruct [:int, :string, :string_with_default, :mandatory_int]
+
+    @type t() :: %__MODULE__{
+            int: integer() | nil,
+            string: String.t() | nil,
+            string_with_default: String.t(),
+            mandatory_int: integer()
+          }
+  end
+end
+
+defmodule TypedStructs.PublicTestStruct do
+  defmodule Actual do
+    use TypedStruct
+
+    typedstruct visibility: :public do
+      field :int, integer()
+      field :string, String.t()
+      field :string_with_default, String.t(), default: "default"
+      field :mandatory_int, integer(), enforce: true
+    end
+
+    def enforce_keys, do: @enforce_keys
+  end
+
+  # Define a second struct with the type expected for TestStruct.
+  defmodule Expected do
+    defstruct [:int, :string, :string_with_default, :mandatory_int]
+
+    @type t() :: %__MODULE__{
+            int: integer() | nil,
+            string: String.t() | nil,
+            string_with_default: String.t(),
+            mandatory_int: integer()
+          }
+  end
+end
+
+defmodule TypedStructs.OpaqueTestStruct do
+  defmodule Actual do
+    use TypedStruct
+
+    typedstruct visibility: :opaque do
+      field :int, integer()
+    end
+  end
+
+  defmodule Expected do
+    defstruct [:int]
+
+    @opaque t() :: %__MODULE__{
+              int: integer() | nil
+            }
+  end
+end
+
+defmodule TypedStructs.PrivateTestStruct do
+  defmodule Actual do
+    use TypedStruct
+
+    typedstruct visibility: :private do
+      field :int, integer()
+    end
+
+    # Needed so that the compiler doesn't remove unused private type t()
+    @opaque tt :: t
+  end
+
+  defmodule Expected do
+    defstruct [:int]
+
+    @typep t :: %__MODULE__{int: integer() | nil}
+    @opaque t2 :: t
+  end
+end
+
+defmodule TypedStructs.Alias do
+  defmodule Without do
+    use TypedStruct
+
+    typedstruct do
+      field :test, TestModule.TestSubModule.t()
+    end
+  end
+
+  defmodule With do
+    use TypedStruct
+
+    typedstruct do
+      alias TestModule.TestSubModule
+
+      field :test, TestSubModule.t()
+    end
+  end
+end


### PR DESCRIPTION
Along with adding the visibility property, this PR fixes compilation issue with Elixir 15 and OTP-26. 
The issue is that `Code.Typespec.fetch_types/1` no longer is able to fetch typespecs from an in-memory module. It only works with modules stored in files on disk.  Consequently, the test cases were reworked to be stored in persistent modules.