### PR TITLE
feat: add a new typedrecord feature (part2 of PR#33)

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,0 +1,2 @@
+* Jean-Philippe Cugnet (author)
+* Serge Aleynikov (implemented visibility and defrecord)

--- a/README.md
+++ b/README.md
@@ -133,6 +133,21 @@ end
 Each field is defined through the
 [`field/2`](https://hexdocs.pm/typed_struct/TypedStruct.html#field/2) macro.
 
+To define a record use the `typedrecord` block:
+
+```elixir
+defmodule Person do
+  use TypedStruct
+
+  typedrecord :person do
+    @typedoc "A person"
+
+    field :name, String.t(),
+    field :age,  non_neg_integer(), default: 0
+  end
+end
+```
+
 ### Options
 
 If you want to enforce all the keys by default, you can do:
@@ -247,6 +262,8 @@ defmodule MyStruct do
   end
 end
 ```
+
+Presently plugins are not supported by the `typedrecord` block.
 
 ### Some available plugins
 
@@ -384,6 +401,29 @@ defmodule MyModule do
             field: term() | nil
           }
   end
+end
+```
+
+To define a typed record, the following definition of the `typedrecord`:
+
+```elixir
+defmodule Person do
+  use TypedStruct
+  typedrecord :person do
+    @typedoc "A person"
+    field :name, String.t()
+    field :age,  non_neg_integer(), default: 0
+  end
+end
+```
+
+becomes:
+
+```elixir
+defmodule Person do
+  use Record
+  Record.defrecord(:person, name: nil, age: 0)
+  @type person :: {:person, String.t()|nil, non_neg_integer()}
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -154,15 +154,26 @@ defmodule MyStruct do
   end
 end
 ```
-
-You can also generate an opaque type for the struct:
+You can also generate an opaque or private type for the struct by using
+the `visibility: :opaque | :private | :public` option:
 
 ```elixir
 defmodule MyOpaqueStruct do
   use TypedStruct
 
   # Generate an opaque type for the struct.
-  typedstruct opaque: true do
+  typedstruct visibility: :opaque do
+    field :name, String.t()
+  end
+end
+```
+
+```elixir
+defmodule MyPrivateStruct do
+  use TypedStruct
+
+  # Generate a private type for the struct.
+  typedstruct visibility: :private do
     field :name, String.t()
   end
 end

--- a/lib/typed_struct.ex
+++ b/lib/typed_struct.ex
@@ -127,17 +127,17 @@ defmodule TypedStruct do
     case TypedStruct.__visibility__(opts) do
       :public ->
         quote bind_quoted: [types: types] do
-          @type t() :: %__MODULE__{unquote_splicing(types)}
+          @type(t() :: %__MODULE__{unquote_splicing(types)})
         end
 
       :opaque ->
         quote bind_quoted: [types: types] do
-          @opaque t() :: %__MODULE__{unquote_splicing(types)}
+          @opaque(t() :: %__MODULE__{unquote_splicing(types)})
         end
 
       :private ->
         quote bind_quoted: [types: types] do
-          @typep t() :: %__MODULE__{unquote_splicing(types)}
+          @typep(t() :: %__MODULE__{unquote_splicing(types)})
         end
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -11,6 +11,7 @@ defmodule TypedStruct.MixProject do
       elixir: "~> 1.6",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
+      elixirc_paths: elixirc_paths(),
 
       # Tools
       dialyzer: dialyzer(),
@@ -55,6 +56,10 @@ defmodule TypedStruct.MixProject do
       # Documentation dependencies
       {:ex_doc, ">= 0.0.0", only: :docs, runtime: false}
     ]
+  end
+
+  defp elixirc_paths() do
+    if Mix.env() == :test, do: ["lib", "test"], else: ["lib"]
   end
 
   # Dialyzer configuration

--- a/test/test_record_structs.ex
+++ b/test/test_record_structs.ex
@@ -1,0 +1,105 @@
+defmodule TypedRecord.Record do
+  defmodule Actual do
+    use TypedStruct
+
+    typedrecord :user do
+      field :one, integer(), default: 1
+      field :two, String.t()
+      field :three, String.t(), default: "def"
+      field :four, atom(), default: :hi
+    end
+  end
+
+  defmodule Expected do
+    require Record
+    Record.defrecord(:user, one: 1, two: nil, three: "def", four: :hi)
+
+    @type user() :: {:user, integer(), String.t() | nil, String.t(), atom()}
+  end
+end
+
+defmodule TypedRecord.Public do
+  defmodule Actual do
+    use TypedStruct
+
+    typedrecord :user, tag: User do
+      field :one, integer(), default: 1
+      field :two, String.t()
+      field :three, String.t(), default: "def"
+      field :four, atom(), default: :hi
+    end
+  end
+
+  defmodule Expected do
+    require Record
+    Record.defrecord(:user, User, one: 1, two: nil, three: "def", four: :hi)
+
+    @type user() :: {User, integer(), String.t() | nil, String.t(), atom()}
+  end
+end
+
+defmodule TypedRecord.VisibilityPublic do
+  defmodule Actual do
+    use TypedStruct
+
+    typedrecord :user, visibility: :public do
+      field :one, integer(), default: 1
+      field :two, String.t()
+      field :three, String.t(), default: "def"
+      field :four, atom(), default: :hi
+    end
+  end
+
+  defmodule Expected do
+    require Record
+    Record.defrecord(:user, one: 1, two: nil, three: "def", four: :hi)
+
+    @type user() :: {:user, integer(), String.t() | nil, String.t(), atom()}
+  end
+end
+
+defmodule TypedRecord.VisibilityOpaque do
+  defmodule Actual do
+    use TypedStruct
+
+    typedrecord :user, visibility: :opaque do
+      field :int, integer()
+    end
+  end
+
+  defmodule Expected do
+    require Record
+    Record.defrecord(:user, int: 1)
+
+    @opaque user() :: {:user, integer()|nil}
+  end
+end
+
+defmodule TypedRecord.VisibilityPrivate do
+  defmodule Actual do
+    use TypedStruct
+
+    typedrecord :user, visibility: :private do
+      field :int, integer()
+    end
+
+    # Needed so that the compiler doesn't remove unused private type t()
+    @opaque tt() :: user()
+  end
+
+  defmodule Expected do
+    require Record
+    Record.defrecord(:user, int: 1)
+
+    @typep user() :: {:user, integer()|nil}
+    @opaque tt() :: user()
+  end
+end
+
+defmodule TypedRecord.TestRecModule do
+  use TypedStruct
+
+  typedrecord :user, module: Rec do
+    field :field, integer(), default: 1
+  end
+end

--- a/test/test_structs.ex
+++ b/test/test_structs.ex
@@ -1,0 +1,111 @@
+defmodule TypedStructs.TestStruct do
+  # Store the bytecode so we can get information from it.
+  defmodule Actual do
+    use TypedStruct
+
+    typedstruct do
+      field :int, integer()
+      field :string, String.t()
+      field :string_with_default, String.t(), default: "default"
+      field :mandatory_int, integer(), enforce: true
+    end
+
+    def enforce_keys, do: @enforce_keys
+  end
+
+  defmodule Expected do
+    defstruct [:int, :string, :string_with_default, :mandatory_int]
+
+    @type t() :: %__MODULE__{
+            int: integer() | nil,
+            string: String.t() | nil,
+            string_with_default: String.t(),
+            mandatory_int: integer()
+          }
+  end
+end
+
+defmodule TypedStructs.PublicTestStruct do
+  defmodule Actual do
+    use TypedStruct
+
+    typedstruct visibility: :public do
+      field :int, integer()
+      field :string, String.t()
+      field :string_with_default, String.t(), default: "default"
+      field :mandatory_int, integer(), enforce: true
+    end
+
+    def enforce_keys, do: @enforce_keys
+  end
+
+  # Define a second struct with the type expected for TestStruct.
+  defmodule Expected do
+    defstruct [:int, :string, :string_with_default, :mandatory_int]
+
+    @type t() :: %__MODULE__{
+            int: integer() | nil,
+            string: String.t() | nil,
+            string_with_default: String.t(),
+            mandatory_int: integer()
+          }
+  end
+end
+
+defmodule TypedStructs.OpaqueTestStruct do
+  defmodule Actual do
+    use TypedStruct
+
+    typedstruct visibility: :opaque do
+      field :int, integer()
+    end
+  end
+
+  defmodule Expected do
+    defstruct [:int]
+
+    @opaque t() :: %__MODULE__{
+              int: integer() | nil
+            }
+  end
+end
+
+defmodule TypedStructs.PrivateTestStruct do
+  defmodule Actual do
+    use TypedStruct
+
+    typedstruct visibility: :private do
+      field :int, integer()
+    end
+
+    # Needed so that the compiler doesn't remove unused private type t()
+    @opaque tt :: t
+  end
+
+  defmodule Expected do
+    defstruct [:int]
+
+    @typep t :: %__MODULE__{int: integer() | nil}
+    @opaque t2 :: t
+  end
+end
+
+defmodule TypedStructs.Alias do
+  defmodule Without do
+    use TypedStruct
+
+    typedstruct do
+      field :test, TestModule.TestSubModule.t()
+    end
+  end
+
+  defmodule With do
+    use TypedStruct
+
+    typedstruct do
+      alias TestModule.TestSubModule
+
+      field :test, TestSubModule.t()
+    end
+  end
+end

--- a/test/test_structs.ex
+++ b/test/test_structs.ex
@@ -1,3 +1,114 @@
+defmodule TypedStructs do
+  ############################################################################
+  ##                                Helpers                                 ##
+  ############################################################################
+
+  def standardize_first_type(module, type_keyword \\ :type)
+       when is_atom(module) do
+    extract_first_type(module, type_keyword)
+    |> standardise(module)
+  end
+
+  # Extracts the first type from a module.
+  defp extract_first_type(bytecode, type_keyword)
+
+  defp extract_first_type(bytecode, type_keyword) when is_binary(bytecode) do
+    case Code.Typespec.fetch_types(bytecode) do
+      {:ok, types} -> Keyword.get(types, type_keyword)
+      _ -> nil
+    end
+  end
+
+  defp extract_first_type(module, type_keyword) when is_atom(module) do
+    {_, bytecode, _} = :code.get_object_code(module)
+    extract_first_type(bytecode, type_keyword)
+  end
+
+  # Standardises a type (removes line numbers and renames the struct to the
+  # standard struct name).
+  defp standardise(type_info, struct)
+
+  defp standardise({name, type, params}, struct) when is_tuple(type),
+    do: {name, standardise(type, struct), params}
+
+  defp standardise({:type, _, type, params}, struct),
+    do: {:type, :line, type, standardise(params, struct)}
+
+  defp standardise({:remote_type, _, params}, struct),
+    do: {:remote_type, :line, standardise(params, struct)}
+
+  defp standardise({:atom, _, struct}, struct),
+    do: {:atom, :line, Placeholder}
+
+  defp standardise({type, _, litteral}, _struct),
+    do: {type, :line, litteral}
+
+  defp standardise(list, struct) when is_list(list),
+    do: Enum.map(list, &standardise(&1, struct))
+
+
+  ############################################################################
+  ##                                Helpers                                 ##
+  ############################################################################
+
+#  defp standardize_first_type(module, type_keyword \\ :type)
+#       when is_atom(module) do
+#    extract_first_type(module, type_keyword)
+#    |> standardise(module)
+#  end
+#
+#  # Extracts the first type from a module.
+#  defp extract_first_type(bytecode, type_keyword)
+#
+#  defp extract_first_type(bytecode, type_keyword) when is_binary(bytecode) do
+#    case Code.Typespec.fetch_types(bytecode) do
+#      {:ok, types} -> Keyword.get(types, type_keyword)
+#      _ -> nil
+#    end
+#  end
+#
+#  defp extract_first_type(module, type_keyword) when is_atom(module) do
+#    {_, bytecode, _} = :code.get_object_code(module)
+#    extract_first_type(bytecode, type_keyword)
+#  end
+#
+#  # Standardises a type (removes line numbers and renames the struct to the
+#  # standard struct name).
+#  defp standardise(type_info, struct)
+#
+#  defp standardise({name, type, params}, struct) when is_tuple(type),
+#    do: {name, standardise(type, struct), params}
+#
+#  defp standardise({:type, _, :union, list}, struct) when is_list(list) do
+#    list =
+#      Enum.map(list, &standardise(&1, struct))
+#      |> Enum.filter(&(&1 != nil and &1 != []))
+#
+#    case list do
+#      [one] -> standardise(one, struct)
+#      _ -> {:type, :line, list}
+#    end
+#  end
+#
+#  defp standardise({:type, _, :union, [value, nil]}, struct),
+#    do: {:type, :line, standardise(value, struct)}
+#
+#  defp standardise({:type, _, type, params}, struct),
+#    do: {:type, :line, type, standardise(params, struct)}
+#
+#  defp standardise({:remote_type, _, params}, struct),
+#    do: {:remote_type, :line, standardise(params, struct)}
+#
+#  defp standardise({:atom, _, struct}, struct),
+#    do: {:atom, :line, TypedRecord.Record.Actual}
+#
+#  defp standardise({type, _, litteral}, _struct),
+#    do: {type, :line, litteral}
+#
+#  defp standardise(list, struct) when is_list(list),
+#    do: Enum.map(list, &standardise(&1, struct))
+end
+
 defmodule TypedStructs.TestStruct do
   # Store the bytecode so we can get information from it.
   defmodule Actual do

--- a/test/typed_record_test.exs
+++ b/test/typed_record_test.exs
@@ -195,15 +195,22 @@ defmodule TypedRecordTest do
   end
 
   test "Typedrecord missing record name" do
-    assert_raise CompileError, ~r"undefined function typedrecord/1", fn ->
-      defmodule ScopeTest do
-        use TypedStruct
+    assert_raise CompileError,
+                 if(Version.compare(System.version(), "1.14.9") == :lt,
+                   do: ~r"undefined function typedrecord/1",
+                   else: ~r"cannot compile module TypedRecordTest.ScopeTest"
+                 ),
+                 fn ->
+                   ExUnit.CaptureIO.capture_io(:stderr, fn ->
+                     defmodule ScopeTest do
+                       use TypedStruct
 
-        typedrecord do
-          field :in_scope, term()
-        end
-      end
-    end
+                       typedrecord do
+                         field :in_scope, term()
+                       end
+                     end
+                   end)
+                 end
   end
 
   test "it is not possible to add twice a field with the same name" do

--- a/test/typed_record_test.exs
+++ b/test/typed_record_test.exs
@@ -1,0 +1,270 @@
+defmodule TypedRecordTest do
+  use ExUnit.Case
+
+  ############################################################################
+  ##                               Test data                                ##
+  ############################################################################
+
+  # Store the bytecode so we can get information from it.
+  {:module, _name, bytecode, _exports} =
+    defmodule TestRecord do
+      use TypedStruct
+
+      typedrecord :user do
+        field :one, integer(), default: 1
+        field :two, String.t()
+        field :three, String.t(), default: "def"
+        field :four, atom(), default: :hi
+      end
+    end
+
+  {:module, _name, bytecode_public, _exports} =
+    defmodule PublicTestRecord do
+      use TypedStruct
+
+      typedrecord :user, tag: User do
+        field :one, integer(), default: 1
+        field :two, String.t()
+        field :three, String.t(), default: "def"
+        field :four, atom(), default: :hi
+      end
+    end
+
+  {:module, _name, bytecode_public2, _exports} =
+    defmodule TestRecordPublic3 do
+      use TypedStruct
+
+      typedrecord :user, visibility: :public do
+        field :one, integer(), default: 1
+        field :two, String.t()
+        field :three, String.t(), default: "def"
+        field :four, atom(), default: :hi
+      end
+    end
+
+  {:module, _name, bytecode_opaque, _exports} =
+    defmodule OpaqueTestRecord do
+      use TypedStruct
+
+      typedrecord :user, visibility: :opaque do
+        field :int, integer()
+      end
+    end
+
+  {:module, _name, bytecode_private, _exports} =
+    defmodule PrivateTestRecord do
+      use TypedStruct
+
+      typedrecord :user, visibility: :private do
+        field :int, integer()
+      end
+
+      # Needed so that the compiler doesn't remove unused private type t()
+      @opaque tt() :: user()
+    end
+
+  defmodule TestRecModule do
+    use TypedStruct
+
+    typedrecord :user, module: Rec do
+      field :field, integer(), default: 1
+    end
+  end
+
+  @bytecode bytecode
+  @bytecode_public bytecode_public
+  @bytecode_public2 bytecode_public2
+  @bytecode_opaque bytecode_opaque
+  @bytecode_private bytecode_private
+
+  ############################################################################
+  ##                             Standard cases                             ##
+  ############################################################################
+
+  test "generates the record with its defaults" do
+    require TypedRecordTest.TestRecord
+    assert TestRecord.user() == {:user, 1, nil, "def", :hi}
+  end
+
+  test "generates a type for the record in default case" do
+    # Define a second struct with the type expected for TestRecord.
+    {:module, _name, bytecode, _exports} =
+      defmodule TestRecord0 do
+        require Record
+        Record.defrecord(:user, one: 1, two: nil, three: "def", four: :hi)
+
+        @type user() :: {:user, integer(), String.t() | nil, String.t(), atom()}
+      end
+
+    type1 = extract_first_type(bytecode)
+    type2 = extract_first_type(@bytecode)
+
+    assert type1 == type2
+  end
+
+  test "generates a type for the record in default case with a record tag" do
+    # Define a second struct with the type expected for TestRecord.
+    {:module, _name, bytecode_public, _exports} =
+      defmodule TestRecordTag do
+        require Record
+        Record.defrecord(:user, User, one: 1, two: nil, three: "def", four: :hi)
+
+        @type user() :: {User, integer(), String.t() | nil, String.t(), atom()}
+      end
+
+    type1 = extract_first_type(bytecode_public)
+    type2 = extract_first_type(@bytecode_public)
+
+    assert type1 == type2
+  end
+
+  test "generates a type for the record with the `visibility: :public`" do
+    # Define a second struct with the type expected for TestRecord.
+    {:module, _name, bytecode_public, _exports} =
+      defmodule TestRecord1 do
+        require Record
+        Record.defrecord(:user, one: 1, two: nil, three: "def", four: :hi)
+
+        @type user() :: {:user, integer(), String.t() | nil, String.t(), atom()}
+      end
+
+    type1 = extract_first_type(bytecode_public)
+    type2 = extract_first_type(@bytecode_public2)
+
+    assert type1 == type2
+  end
+
+  test "generates an opaque type if `visibility: :opaque` is set" do
+    # Define a second struct with the type expected for TestRecord.
+    {:module, _name, bytecode_expected, _exports} =
+      defmodule TestRecord2 do
+        require Record
+        Record.defrecord(:user, int: 1)
+
+        @opaque user() :: {:user, integer()}
+      end
+
+    type1 = extract_first_type(bytecode_expected, :opaque)
+    type2 = extract_first_type(@bytecode_opaque, :opaque)
+
+    assert type1 == type2
+  end
+
+  test "generates a private type if `visibility: private` is set" do
+    # Define a second struct with the type expected for TestRecord.
+    {:module, _name, bytecode_private_expected, _exports} =
+      defmodule TestRecord3 do
+        require Record
+        Record.defrecord(:user, int: 1)
+
+        @typep user() :: {:user, integer()}
+        @opaque t2() :: user()
+      end
+
+    type1 = extract_first_type(bytecode_private_expected, :typep)
+    type2 = extract_first_type(@bytecode_private, :typep)
+
+    assert type1 == type2
+  end
+
+  test "generates the struct in a submodule if `module: ModuleName` is set" do
+    require TestRecModule.Rec
+    assert TestRecModule.Rec.user() == {:user, 1}
+  end
+
+  ############################################################################
+  ##                                Problems                                ##
+  ############################################################################
+
+  test "Typedrecord field's name is not an atom" do
+    assert_raise(
+      ArgumentError,
+      "a field name must be an atom, got \"one\"",
+      fn ->
+        defmodule TestRecordBadKeyType do
+          use TypedStruct
+
+          typedrecord :user do
+            field "one", integer(), default: 1
+            field :two, String.t()
+            field :three, atom(), default: :hi
+          end
+        end
+      end
+    )
+  end
+
+  test "Typedrecord missing record name" do
+    assert_raise CompileError, ~r"undefined function typedrecord/1", fn ->
+      defmodule ScopeTest do
+        use TypedStruct
+
+        typedrecord do
+          field :in_scope, term()
+        end
+      end
+    end
+  end
+
+  test "it is not possible to add twice a field with the same name" do
+    assert_raise ArgumentError, "the field :name is already set", fn ->
+      defmodule InvalidStruct do
+        use TypedStruct
+
+        typedrecord :user do
+          field :name, String.t()
+          field :name, integer()
+        end
+      end
+    end
+  end
+
+  ############################################################################
+  ##                                Helpers                                 ##
+  ############################################################################
+
+  # Extracts the first type from a module.
+  defp extract_first_type(bytecode, type_keyword \\ :type) do
+    case Code.Typespec.fetch_types(bytecode) do
+      {:ok, types} -> Keyword.get(types, type_keyword) |> standardise()
+      _ -> nil
+    end
+  end
+
+  # Standardises a type (removes line numbers and renames the struct to the
+  # standard struct name).
+  defp standardise(type_info)
+
+  defp standardise({name, tp, params}) when is_tuple(tp),
+    do: {name, standardise(tp), params}
+
+  defp standardise({:type, _, :union, list}) when is_list(list) do
+    list =
+      Enum.map(list, &standardise(&1))
+      |> Enum.filter(&(&1 != nil and &1 != []))
+
+    case list do
+      [one] -> standardise(one)
+      _ -> {:type, :line, list}
+    end
+  end
+
+  defp standardise({:type, _, :union, [value, nil]}),
+    do: {:type, :line, standardise(value)}
+
+  defp standardise({:type, _, type, params}),
+    do: {:type, :line, type, standardise(params)}
+
+  defp standardise({:remote_type, _, params}),
+    do: {:remote_type, :line, standardise(params)}
+
+  defp standardise({:atom, _, value}), do: value
+
+  defp standardise({type, _, litteral}),
+    do: {type, :line, standardise(litteral)}
+
+  defp standardise(type) when is_atom(type), do: type
+
+  defp standardise(list) when is_list(list),
+    do: for(i <- list, i != [], do: standardise(i))
+end

--- a/test/typed_record_test.exs
+++ b/test/typed_record_test.exs
@@ -1,175 +1,55 @@
 defmodule TypedRecordTest do
   use ExUnit.Case
 
-  ############################################################################
-  ##                               Test data                                ##
-  ############################################################################
-
-  # Store the bytecode so we can get information from it.
-  {:module, _name, bytecode, _exports} =
-    defmodule TestRecord do
-      use TypedStruct
-
-      typedrecord :user do
-        field :one, integer(), default: 1
-        field :two, String.t()
-        field :three, String.t(), default: "def"
-        field :four, atom(), default: :hi
-      end
-    end
-
-  {:module, _name, bytecode_public, _exports} =
-    defmodule PublicTestRecord do
-      use TypedStruct
-
-      typedrecord :user, tag: User do
-        field :one, integer(), default: 1
-        field :two, String.t()
-        field :three, String.t(), default: "def"
-        field :four, atom(), default: :hi
-      end
-    end
-
-  {:module, _name, bytecode_public2, _exports} =
-    defmodule TestRecordPublic3 do
-      use TypedStruct
-
-      typedrecord :user, visibility: :public do
-        field :one, integer(), default: 1
-        field :two, String.t()
-        field :three, String.t(), default: "def"
-        field :four, atom(), default: :hi
-      end
-    end
-
-  {:module, _name, bytecode_opaque, _exports} =
-    defmodule OpaqueTestRecord do
-      use TypedStruct
-
-      typedrecord :user, visibility: :opaque do
-        field :int, integer()
-      end
-    end
-
-  {:module, _name, bytecode_private, _exports} =
-    defmodule PrivateTestRecord do
-      use TypedStruct
-
-      typedrecord :user, visibility: :private do
-        field :int, integer()
-      end
-
-      # Needed so that the compiler doesn't remove unused private type t()
-      @opaque tt() :: user()
-    end
-
-  defmodule TestRecModule do
-    use TypedStruct
-
-    typedrecord :user, module: Rec do
-      field :field, integer(), default: 1
-    end
-  end
-
-  @bytecode bytecode
-  @bytecode_public bytecode_public
-  @bytecode_public2 bytecode_public2
-  @bytecode_opaque bytecode_opaque
-  @bytecode_private bytecode_private
+  import TypedStructs
 
   ############################################################################
   ##                             Standard cases                             ##
   ############################################################################
 
   test "generates the record with its defaults" do
-    require TypedRecordTest.TestRecord
-    assert TestRecord.user() == {:user, 1, nil, "def", :hi}
+    require TypedRecord.Record.Actual
+    assert TypedRecord.Record.Actual.user() == {:user, 1, nil, "def", :hi}
   end
 
   test "generates a type for the record in default case" do
-    # Define a second struct with the type expected for TestRecord.
-    {:module, _name, bytecode, _exports} =
-      defmodule TestRecord0 do
-        require Record
-        Record.defrecord(:user, one: 1, two: nil, three: "def", four: :hi)
-
-        @type user() :: {:user, integer(), String.t() | nil, String.t(), atom()}
-      end
-
-    type1 = extract_first_type(bytecode)
-    type2 = extract_first_type(@bytecode)
+    type1 = standardize_first_type(TypedRecord.Record.Actual)
+    type2 = standardize_first_type(TypedRecord.Record.Expected)
 
     assert type1 == type2
   end
 
   test "generates a type for the record in default case with a record tag" do
-    # Define a second struct with the type expected for TestRecord.
-    {:module, _name, bytecode_public, _exports} =
-      defmodule TestRecordTag do
-        require Record
-        Record.defrecord(:user, User, one: 1, two: nil, three: "def", four: :hi)
-
-        @type user() :: {User, integer(), String.t() | nil, String.t(), atom()}
-      end
-
-    type1 = extract_first_type(bytecode_public)
-    type2 = extract_first_type(@bytecode_public)
+    type1 = standardize_first_type(TypedRecord.Public.Actual)
+    type2 = standardize_first_type(TypedRecord.Public.Expected)
 
     assert type1 == type2
   end
 
   test "generates a type for the record with the `visibility: :public`" do
-    # Define a second struct with the type expected for TestRecord.
-    {:module, _name, bytecode_public, _exports} =
-      defmodule TestRecord1 do
-        require Record
-        Record.defrecord(:user, one: 1, two: nil, three: "def", four: :hi)
-
-        @type user() :: {:user, integer(), String.t() | nil, String.t(), atom()}
-      end
-
-    type1 = extract_first_type(bytecode_public)
-    type2 = extract_first_type(@bytecode_public2)
+    type1 = standardize_first_type(TypedRecord.VisibilityPublic.Actual)
+    type2 = standardize_first_type(TypedRecord.VisibilityPublic.Expected)
 
     assert type1 == type2
   end
 
   test "generates an opaque type if `visibility: :opaque` is set" do
-    # Define a second struct with the type expected for TestRecord.
-    {:module, _name, bytecode_expected, _exports} =
-      defmodule TestRecord2 do
-        require Record
-        Record.defrecord(:user, int: 1)
-
-        @opaque user() :: {:user, integer()}
-      end
-
-    type1 = extract_first_type(bytecode_expected, :opaque)
-    type2 = extract_first_type(@bytecode_opaque, :opaque)
+    type1 = standardize_first_type(TypedRecord.VisibilityOpaque.Actual, :opaque)
+    type2 = standardize_first_type(TypedRecord.VisibilityOpaque.Expected, :opaque)
 
     assert type1 == type2
   end
 
   test "generates a private type if `visibility: private` is set" do
-    # Define a second struct with the type expected for TestRecord.
-    {:module, _name, bytecode_private_expected, _exports} =
-      defmodule TestRecord3 do
-        require Record
-        Record.defrecord(:user, int: 1)
-
-        @typep user() :: {:user, integer()}
-        @opaque t2() :: user()
-      end
-
-    type1 = extract_first_type(bytecode_private_expected, :typep)
-    type2 = extract_first_type(@bytecode_private, :typep)
+    type1 = standardize_first_type(TypedRecord.VisibilityPrivate.Actual, :typep)
+    type2 = standardize_first_type(TypedRecord.VisibilityPrivate.Expected, :typep)
 
     assert type1 == type2
   end
 
   test "generates the struct in a submodule if `module: ModuleName` is set" do
-    require TestRecModule.Rec
-    assert TestRecModule.Rec.user() == {:user, 1}
+    require TypedRecord.TestRecModule.Rec
+    assert TypedRecord.TestRecModule.Rec.user() == {:user, 1}
   end
 
   ############################################################################
@@ -225,53 +105,4 @@ defmodule TypedRecordTest do
       end
     end
   end
-
-  ############################################################################
-  ##                                Helpers                                 ##
-  ############################################################################
-
-  # Extracts the first type from a module.
-  defp extract_first_type(bytecode, type_keyword \\ :type) do
-    case Code.Typespec.fetch_types(bytecode) do
-      {:ok, types} -> Keyword.get(types, type_keyword) |> standardise()
-      _ -> nil
-    end
-  end
-
-  # Standardises a type (removes line numbers and renames the struct to the
-  # standard struct name).
-  defp standardise(type_info)
-
-  defp standardise({name, tp, params}) when is_tuple(tp),
-    do: {name, standardise(tp), params}
-
-  defp standardise({:type, _, :union, list}) when is_list(list) do
-    list =
-      Enum.map(list, &standardise(&1))
-      |> Enum.filter(&(&1 != nil and &1 != []))
-
-    case list do
-      [one] -> standardise(one)
-      _ -> {:type, :line, list}
-    end
-  end
-
-  defp standardise({:type, _, :union, [value, nil]}),
-    do: {:type, :line, standardise(value)}
-
-  defp standardise({:type, _, type, params}),
-    do: {:type, :line, type, standardise(params)}
-
-  defp standardise({:remote_type, _, params}),
-    do: {:remote_type, :line, standardise(params)}
-
-  defp standardise({:atom, _, value}), do: value
-
-  defp standardise({type, _, litteral}),
-    do: {type, :line, standardise(litteral)}
-
-  defp standardise(type) when is_atom(type), do: type
-
-  defp standardise(list) when is_list(list),
-    do: for(i <- list, i != [], do: standardise(i))
 end


### PR DESCRIPTION
This PR was based on the [saleyn:visibility](https://github.com/saleyn/typed_struct/tree/visibility) branch and is inclusive of the visibility feature.  This is meant to remove merging conflicts after the PR#39 is merged.